### PR TITLE
release v1.3.0; new workflow function for centralizing logfiles

### DIFF
--- a/ExchangeLogs/ExchangeLogs.psd1
+++ b/ExchangeLogs/ExchangeLogs.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'ExchangeLogs.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.2.4.0'
+    ModuleVersion     = '1.3.0.0'
 
     # ID used to uniquely identify this module
     GUID              = '4182cc5a-25fa-434a-a852-853483481e35'
@@ -41,7 +41,9 @@
 
     # Functions to export from this module
     FunctionsToExport = @(
-        'Get-ELExchangeLog'
+        'Get-ELExchangeLog',
+        'Invoke-ELCentralizeLogging',
+        'Invoke-ELExchangeLogConvert'
     )
 
     # Cmdlets to export from this module

--- a/ExchangeLogs/ExchangeLogs.psd1
+++ b/ExchangeLogs/ExchangeLogs.psd1
@@ -26,7 +26,7 @@
     # Modules that must be imported into the global environment prior to importing
     # this module
     RequiredModules   = @(
-        @{ ModuleName = 'PSFramework'; ModuleVersion = '1.1.59' }
+        @{ ModuleName = 'PSFramework'; ModuleVersion = '1.4.146' }
         @{ ModuleName = 'PoshRSJob'; ModuleVersion = '1.7.4.4' }
     )
 

--- a/ExchangeLogs/changelog.md
+++ b/ExchangeLogs/changelog.md
@@ -1,7 +1,17 @@
 ﻿# Changelog
+## 1.3.0 (2020-09-02)
+- New: Invoke-ELCentralizeLogging
+    - Workflow function intendet to create a centralized logging directory to gather logfiles (supported by the module) from all exchange servers into a single directory or fileshare and withing a folder structure eligible for further processing.
+    - See help for more information
+- New: Invoke-ELExchangeLogConvert
+    - Workflow function intendet to parse through a folder structure (staging directory, filled by Invoke-ELCentralizeLogging), find all exchange logfiles (supported by the module) and convert the files into flatten and better read-/processable CSV files.
+    - See help for more information
+- Fix: Get-ELExchangeLog
+    - Function new can handle logs with multiple metadata lines in the conent. (service restarts or config changes can bring additional header information to W3C logfiles)
+
 ## 1.2.4 (2020-07-25)
 - Fix: Get-ELExchangeLog
-    - fixing MailFrom and RcptTo extraction from smtp logs on multiple mail objects in a single session
+    - Fixing MailFrom and RcptTo extraction from smtp logs on multiple mail objects in a single session
 
 ## 1.2.3 (2020-07-19)
 - Fix: Get-ELExchangeLog
@@ -18,8 +28,8 @@
     - POP3 and IMAP logfiles got format data to optimize output to console with Format-List, Format-Table and Out-Gridview
     - Add alias 'gel' on command 'Get-ELExchangeLog'
 - Upd: general
-    - add module logo
-    - add descriptions and a little bit of documentation
+    - Add module logo
+    - Add descriptions and a little bit of documentation
 
 ## 1.2.0 (2020-07-05)
 - New: Get-ELExchangeLog
@@ -37,8 +47,8 @@
     - Add support for importing and interpreting SMTP send log files.
     - Add more detailed fields on output records. TLS certificate informations are now separated into fields for subject, issuer, validity time, subject alternative names, ...
 - Fix: Get-ELExchangeLog
-    - minor bugfixes on record processing when session in the logfile is not having all TLS information
-    - minor time and output optimizations
+    - Minor bugfixes on record processing when session in the logfile is not having all TLS information
+    - Minor time and output optimizations
 
 ## 1.0.0 (2020-06-26)
 - New: Frist stable version 1.0.0\

--- a/ExchangeLogs/functions/Get-ELExchangeLog.ps1
+++ b/ExchangeLogs/functions/Get-ELExchangeLog.ps1
@@ -68,7 +68,7 @@
             }
             if ($Recurse) { $options.Add("Recurse", $true) }
             try {
-                $ChildItemList = Get-ChildItem @options
+                $ChildItemList = Get-ChildItem @options | Where-Object Length -ne 0
                 if ($Filter) {
                     $ChildItemList = $ChildItemList | Where-Object Name -like $Filter
                 }

--- a/ExchangeLogs/functions/Invoke-ELCentralizeLogging.ps1
+++ b/ExchangeLogs/functions/Invoke-ELCentralizeLogging.ps1
@@ -1,0 +1,352 @@
+﻿function Invoke-ELCentralizeLogging {
+    <#
+    .SYNOPSIS
+        Copy function for centralizing log files out of exchange servers
+
+    .DESCRIPTION
+        This one is a utility function inside the ExchangeLogs module.
+        It's intendet to create a centralized logging directory to gather logfiles (supported by the module) from all exchange servers into a single directory or fileshare and withing a folder structure eligible for further processing.
+
+        The intented workflow provided by this function:
+          - find a exchange server to connect on via active directory serviceconnectionpoitns
+          - connect to exchange server
+          - find all exchange servers and subsequently query logging path for supported services
+          - copy the logfiles out of the exchange servers to a central logging share (usually a staging folder, due to further processing with Invoke-ELExchangeLogConvert. See more info in Invoke-ELExchangeLogConvert help.)
+          - remembering last processed file, to reduce noise and load on next processing
+
+        Requirements:
+          - The executing user needs the permission to connect with powershell remoting into exchange server
+                - Predefined roles like "Organization Management" or "Server Management" can be used
+                - Find/ create a individual management role with Get-ManagementRole cmdlet
+          - The executing user needs permission to access the administrative shares on the server
+          - The users needs read/write permission on the central network share
+
+        The workflow will be:
+            - First, find all logs and centralize them into a staging-folder with 'Invoke-ELCentralizeLogging'
+            - Second, process staging-folder with 'Invoke-ELExchangeLogConvert' and build read- and processable CSV files in a reporting-folder
+            - Use other BI-/Analytical tools to process the CSV Files in the reporting folder
+
+    .PARAMETER Destination
+        The path to copy all logfiles from the exchange server(s) to.
+        Can be a local directory, or a fileshare (recommended)
+
+    .PARAMETER FilterServer
+        Filter parameter to in-/exclude certain exchange server from processing.
+        The filter is applied in a "like"-matching process, so wildcards and multiple values for inclusion are supportet.
+
+        Default value: *
+
+    .PARAMETER IncludeLog
+        Filter parameter to specify the type of logs to query and process.
+        This filter ofers a predefined set of values: "All", "HubTransport", "Frontendtransport", "IMAP4", "POP3"
+
+        Multiple values are supported.
+        Default value: All
+
+    .PARAMETER DirectoryLastProcessedFile
+        The folder where the function search for the information which file was processed as last file on the previous run.
+        Should be a local directory, but can also be a share.
+
+        Default value: C:\Administration\Logs\Exchange\CentralizedLogs
+
+    .PARAMETER LogFile
+        The logfile to archive processing information.
+
+        Default value: -not specified-
+        Recommended:   C:\Administration\Logs\Exchange\CentralizeExchangeLogs.log
+
+    .PARAMETER WhatIf
+        If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+
+    .PARAMETER Confirm
+        If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
+    .EXAMPLE
+        PS C:\> Invoke-ELCentralizeLogging -Destination "\\SRV01\Logs\Exchange\Staging"
+
+        Gathers all exchange servers with all supported logs and copy it to the share "\\SRV01\Logs\Exchange\Staging".
+        No log is written, there are basic output information on the console and extended logging information in the session via "Get-PSFMessage".
+
+    .EXAMPLE
+        PS C:\> Invoke-ELCentralizeLogging -Destination "\\$($env:USERDNSDOMAIN)\system\Logs\Exchange\Staging" -LogFile "C:\Administration\Logs\CentralizedLogs\CentralizeExchangeLogs.log"
+
+        Gathers all exchange servers with all supported logs and copy it to the share "\\$($env:USERDNSDOMAIN)\System\Logs\Exchange\Staging". This one assumes, there is a DFS share "System" in your domain with a folder "logs".
+        Script actions are written to a logfile 'C:\Administration\Logs\CentralizedLogs\CentralizeExchangeLogs.log' for informationtracking of the process state. This one is usally recommended for usage in scheduled tasks/ automation.
+
+        Additonally, there are basic output information on the console and extended logging information in the session via "Get-PSFMessage".
+
+    .EXAMPLE
+        PS C:\> Invoke-ELCentralizeLogging -Destination "\\SRV01\Logs\Exchange\Staging" -DirectoryLastProcessedFile "C:\Administration\Logs\CentralizedLogs" -LogFile "C:\Administration\Logs\CentralizedLogs\CentralizeExchangeLogs.log" -FilterServer "Ex01", "Ex02" -IncludeLog "HubTransport", "Frontendtransport"
+
+        Gathers only exchange server "Ex01" and "Ex02" and only SMTP logs (Hub and Frontend transport service) and copy it to the share "\\SRV01\Logs\Exchange\Staging".
+        Last processed files will be remembered in directory "C:\Administration\Logs\CentralizedLogs". This is the default used directory, but it can be changed to anything else.
+        Script actions are written to a logfile 'C:\Administration\Logs\CentralizedLogs\CentralizeExchangeLogs.log' for informationtracking of the process state. This one is usally recommended for usage in scheduled tasks/ automation.
+
+        Additonally, there are basic output information on the console and extended logging information in the session via "Get-PSFMessage".
+
+    .EXAMPLE
+        PS C:\> Invoke-ELCentralizeLogging -Path "\\$($env:USERDNSDOMAIN)\system\Logs\Exchange\Staging" -LastFileDirectory "C:\Administration\Logs\CentralizedLogs"
+
+        Same result as in previous examples but with alias "Path" and "LastFileDirectory" on parameters "Destination" and "DirectoryLastProcessedFile".
+#>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory = $true)]
+        [Alias("Path")]
+        [String]
+        $Destination,
+
+        [string[]]
+        $FilterServer = "*",
+
+        [ValidateSet("All", "HubTransport", "Frontendtransport", "IMAP4", "POP3")]
+        [string[]]
+        $IncludeLog = "All",
+
+        [Alias("LastFileDirectory")]
+        [String]
+        $DirectoryLastProcessedFile = "C:\Administration\Logs\Exchange\CentralizedLogs",
+
+        [String]
+        $LogFile
+    )
+
+    begin {}
+
+    process {}
+
+    end {
+        #region Init and prerequisites
+        if ($LogFile) { Initialize-LogFile -LogFile $LogFile -AlternateLogName $MyInvocation.MyCommand -LogInstanceName "ExchangeLogs" }
+        Write-PSFMessage -Level Host -Message "----- Start script -----" -Tag "ExchangeLogs"
+
+        # variables
+        Write-PSFMessage -Level System -Message "Initialize variables" -Tag "ExchangeLogs"
+        if ($DirectoryLastProcessedFile.EndsWith("\")) { $DirectoryLastProcessedFile = $DirectoryLastProcessedFile.TrimEnd("\") }
+        if ($Destination.EndsWith("\")) { $Destination = $Destination.TrimEnd("\") }
+
+        # find exchange server in active directory
+        try {
+            $adsiSearch = ([ADSISearcher]'(&(objectclass=serviceconnectionpoint)(|(keywords=77378F46-2C66-4aa9-A6A6-3E7A48B19596)(keywords="67661d7F-8FC4-4fa7-BFAC-E1D7794C1F68")))')
+            $adsiSearch.SearchRoot = [adsi]"LDAP://CN=Services,CN=Configuration,$(([adsi]::new()).distinguishedName)"
+            $exServerName = ($adsiSearch.FindOne()).Properties['Name']
+        } catch {
+            Stop-PSFFunction -Message "Unable to query active directory for exchange serviceconnectionpoint (Message: $($_.exception.message))" -ErrorRecord $_ -Exception $_.exception -Tag "ExchangeLogs"
+            throw
+        }
+        Write-PSFMessage -Level System -Message "Found exchange server: $($exServerName)" -Tag "ExchangeLogs"
+
+
+        # check directories
+        Write-PSFMessage -Level System -Message "Check directory to memorize last processed file ($($DirectoryLastProcessedFile))" -Tag "ExchangeLogs"
+        if (-not (Test-Path -Path $DirectoryLastProcessedFile)) {
+            try {
+                $null = New-Item -Path $DirectoryLastProcessedFile -ItemType Directory -Force -ErrorAction Stop
+            } catch {
+                Stop-PSFFunction -Message "Error creating directory to memorize last processed file '$($DirectoryLastProcessedFile)' (Message: $($_.exception.message))" -ErrorRecord $_ -Exception $_.exception  -Tag "ExchangeLogs"
+                throw
+            }
+        }
+
+        Write-PSFMessage -Level System -Message "Check destination directory ($($Destination))" -Tag "ExchangeLogs"
+        if (-not (Test-Path -Path $Destination)) {
+            try {
+                $null = New-Item -Path $Destination -ItemType Directory -Force -ErrorAction Stop
+            } catch {
+                Stop-PSFFunction -Message "Error creating destination directory '$($DirectoryLastProcessedFile)' (Message: $($_.exception.message))" -ErrorRecord $_ -Exception $_.exception -Tag "ExchangeLogs"
+                throw
+            }
+        }
+
+
+        # connect to exchange server
+        Write-PSFMessage -Level Verbose -Message "Init exchange session" -Tag "ExchangeLogs"
+        try {
+            $exSession = New-PSSession -ConfigurationName Microsoft.Exchange -ErrorAction Stop -ConnectionUri "http://$($exServerName)/PowerShell/"
+            $null = Import-PSSession $exSession -DisableNameChecking -ErrorAction Stop
+        } catch {
+            Stop-PSFFunction -Message "Error connecting exchange session '$($exServerName)' (Message: $($_.exception.message))" -ErrorRecord $_ -Exception $_.exception -Tag "ExchangeLogs"
+            throw
+        }
+        Write-PSFMessage -Level Verbose -Message "Created $($exSession.count) sessions. Server:$($exServerName)" -Tag "ExchangeLogs"
+
+
+        #endregion Init and prereqs
+
+
+
+        #region Query Logdata from exchange
+        # query log paths
+        $exServer = Get-ExchangeServer
+        $exServer = foreach ($filterItem in $FilterServer) {
+            $exServer | Where-Object -Property Name -Like $filterItem
+        }
+        $exServer = $exServer | Sort-Object -Property Name -Unique
+        Write-PSFMessage -Level Verbose -Message "Found $($exServer.count) exchange server" -Tag "ExchangeLogs"
+
+        if("All" -in $IncludeLog -or "HubTransport" -in $IncludeLog) {
+            $logPathSmtpHub = Get-TransportService | Sort-Object -Property Name | Select-Object -Property Name, SendProtocolLogPath, ReceiveProtocolLogPath
+            Write-PSFMessage -Level Verbose -Message "Found $($logPathSmtpHub.count) TransportService" -Tag "ExchangeLogs"
+        }
+
+        if("All" -in $IncludeLog -or "Frontendtransport" -in $IncludeLog) {
+            $logPathSmtpFrontEnd = Get-FrontEndTransportService | Sort-Object -Property Name | Select-Object -Property Name, SendProtocolLogPath, ReceiveProtocolLogPath
+            Write-PSFMessage -Level Verbose -Message "Found $($logPathSmtpFrontEnd.count) FrontEndTransportService" -Tag "ExchangeLogs"
+        }
+
+        if("All" -in $IncludeLog -or "IMAP4" -in $IncludeLog) {
+            $logPathImap = $exServer | ForEach-Object { Get-ImapSettings -Server $_.name } | Sort-Object -Property Server | Select-Object -Property Server, LogFileLocation
+            Write-PSFMessage -Level Verbose -Message "Found $($logPathImap.count) ImapSettings" -Tag "ExchangeLogs"
+        }
+
+        if("All" -in $IncludeLog -or "POP3" -in $IncludeLog) {
+            $logPathPop = $exServer | ForEach-Object { Get-PopSettings -Server $_.name } | Sort-Object -Property Server | Select-Object -Property Server, LogFileLocation
+            Write-PSFMessage -Level Verbose -Message "Found $($logPathPop.count) PopSettings" -Tag "ExchangeLogs"
+        }
+
+
+        # build server/path list
+        $sourcePaths = @()
+        # SMTP Hub Transportservice
+        foreach ($item in $logPathSmtpHub) {
+            $sourcePaths += [PSCustomObject]@{
+                "ComputerName" = $item.Name
+                "Path"         = $item.SendProtocolLogPath
+                "Type"         = "Transport-Hub"
+            }
+            $sourcePaths += [PSCustomObject]@{
+                "ComputerName" = $item.Name
+                "Path"         = $item.ReceiveProtocolLogPath
+                "Type"         = "Transport-Hub"
+            }
+        }
+
+        # SMTP Frontend Transportservice
+        foreach ($item in $logPathSmtpFrontEnd) {
+            $sourcePaths += [PSCustomObject]@{
+                "ComputerName" = $item.Name
+                "Path"         = $item.SendProtocolLogPath
+                "Type"         = "Transport-FrontEnd"
+            }
+            $sourcePaths += [PSCustomObject]@{
+                "ComputerName" = $item.Name
+                "Path"         = $item.ReceiveProtocolLogPath
+                "Type"         = "Transport-FrontEnd"
+            }
+        }
+
+        # IMAP service
+        foreach ($item in $logPathImap) {
+            $sourcePaths += [PSCustomObject]@{
+                "ComputerName" = $item.Server
+                "Path"         = $item.LogFileLocation
+                "Type"         = "ClientAccess"
+            }
+        }
+
+        # POP3 service
+        foreach ($item in $logPathPop) {
+            $sourcePaths += [PSCustomObject]@{
+                "ComputerName" = $item.Server
+                "Path"         = $item.LogFileLocation
+                "Type"         = "ClientAccess"
+            }
+        }
+        $sourcePaths = $sourcePaths | Sort-Object ComputerName, Path
+        Write-PSFMessage -Level Verbose -Message "$($sourcePaths.count) paths to process." -Tag "ExchangeLogs"
+
+
+        #endregion Query Logdata from exchange
+
+
+
+        #region process logfiles
+        Write-PSFMessage -Level Host -Message "Start working through each server and each directory" -Tag "ExchangeLogs"
+
+
+        # work through each server and each directory
+        foreach ($server in $exServer.name) {
+            Write-PSFMessage -Level Verbose -Message "Working with $($server)" | Out-File -FilePath $LogFile -Encoding default -Force -Append
+            $sourcePathInServer = $sourcePaths | Where-Object ComputerName -like $server
+
+            foreach ($source in $sourcePathInServer) {
+                # variables for directory
+                $counter = 0
+                $processedFiles = @()
+                $lastFile = "$($DirectoryLastProcessedFile)\Last-$($source.Type)-$($source.Path.split("\")[-1])-$($server).xml"
+                $destinationPath = "$($Destination)\$($source.Type)\$($source.Path.split("\")[-1])\$($server)"
+
+                Write-PSFMessage -Level Verbose -Message "Processing: $($source) --to--> '$destinationPath'" -Tag "ExchangeLogs"
+
+                # test and create destination directory
+                Write-PSFMessage -Level VeryVerbose -Message "Check destination path '$($destinationPath)'" -Tag "ExchangeLogs"
+                if (-not (Test-Path -Path $destinationPath)) {
+                    try {
+                        $null = New-Item -Path $destinationPath -ItemType Directory -Force
+                    } catch {
+                        Stop-PSFFunction -Message "Unable to create directory '$($destinationPath)' (Message: $($_.Exception.Message))" -ErrorRecord $_ -Exception $_.exception -Tag "ExchangeLogs"
+                        throw
+                    }
+                }
+
+                # gathering files
+                $sourcePath = "\\$($server)\$($source.path.Replace(":","$"))"
+                $sourceFiles = Get-ChildItem -Path $sourcePath | Sort-Object -Property Name
+                Write-PSFMessage -Level VeryVerbose -Message "There are $($sourceFiles.count) files in $($source)" -Tag "ExchangeLogs"
+
+                # enumerate files in source to getting an filterable order
+                foreach ($file in $sourceFiles) {
+                    $file | Add-Member -NotePropertyName "Order" -NotePropertyValue $counter -Force
+                    $counter++
+                }
+
+                # if exist, query last processed file
+                if (Test-Path -Path $LastFile) { $lastFileProcessed = Import-PSFClixml -Path $LastFile } else { $lastFileProcessed = $null }
+                if ($lastFileProcessed) {
+                    $sourceFileStartFilter = $sourceFiles | Where-Object Name -like $lastFileProcessed.Name
+                    $sourceFiles = $sourceFiles | Where-Object order -gt $sourceFileStartFilter.Order
+                }
+
+                # ignore current logfile
+                $sourceFiles = $sourceFiles[0 .. ($sourceFiles.count - 2)]
+                Write-PSFMessage -Level VeryVerbose -Message "$($sourceFiles.count) files to process" -Tag "ExchangeLogs"
+
+
+                # copy files to destination
+                foreach ($file in $sourceFiles) {
+                    Write-PSFMessage -Level Debug -Message "Copy $($file.Name)" -Tag "ExchangeLogs"
+                    try {
+                        if ($pscmdlet.ShouldProcess("$($file.FullName) to $($destinationPath)", "Copy")) {
+                            Copy-Item -Path $file.FullName -Destination $destinationPath -ErrorAction Stop
+                        }
+                        $processedFiles += $file
+                    } catch {
+                        Stop-PSFFunction -Message "Unable to copy file $($file.name) to $($destinationPath). (Message: $($_.Exception.Message))" -ErrorRecord $_ -Exception $_.exception -Tag "ExchangeLogs"
+                        throw
+                    }
+                }
+
+
+                # export lastprocessed file for next run
+                if ($processedFiles) {
+                    Write-PSFMessage -Level Host -Message "Processed $($processedFiles.count) files and remembering LastFileProcessed: $($processedFiles[-1].FullName)" -Tag "ExchangeLogs"
+                    if ($pscmdlet.ShouldProcess("Last processed file '$($processedFiles[-1].FullName)' to $($lastFile)", "Export")) {
+                        $processedFiles[-1] | Export-PSFClixml -Path $lastFile -Force
+                    }
+                } else {
+                    Write-PSFMessage -Level Host -Message "No files processed from directory: $($sourcePath)" -Tag "ExchangeLogs"
+                }
+            }
+        }
+        #endregion process logfiles
+
+
+
+        #region cleanup
+        Write-PSFMessage -Level VeryVerbose -Message "Closing exchange session" -Tag "ExchangeLogs"
+        $exSession | Remove-PSSession
+
+        Write-PSFMessage -Level Host -Message "*** Finishing script ***" -Tag "ExchangeLogs"
+        #endregion cleanup
+    }
+}

--- a/ExchangeLogs/functions/Invoke-ELExchangeLogConvert.ps1
+++ b/ExchangeLogs/functions/Invoke-ELExchangeLogConvert.ps1
@@ -62,15 +62,29 @@
         If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
 
     .EXAMPLE
-        PS C:\> Invoke-ELExchangeLogConvert -Source "\\SRV01\Logs\Exchange\Staging" -Destination "\\SRV01\Logs\Exchange\Reporting" -Archive "\\SRV01\Logs\Exchange\Archive"
+        PS C:\> Invoke-ELExchangeLogConvert -Source "\\SRV01\Logs\Exchange\Staging"
 
+        This will convert *.log files in all folders in path "\\SRV01\Logs\Exchange\Staging".
+        The parameter "Source" can also be used with the alias "Path".
+
+        Converted data will be put in CSV files in a folder "Reporting" in path "\\SRV01\Logs\Exchange".
+        Processed files will be archived in a folder "Archive" in path "\\SRV01\Logs\Exchange".
 
     .EXAMPLE
-        PS C:\> Invoke-ELExchangeLogConvert -Source "\\$($env:USERDNSDOMAIN)\System\Logs\Exchange\Staging" -Destination "\\$($env:USERDNSDOMAIN)\System\Logs\Exchange\Reporting" -Archive "\\$($env:USERDNSDOMAIN)\system\Logs\Exchange\Archive" -MaxFileCount 1000 -Log "C:\Administration\Logs\Exchange\ExchangeLogConvert.log"
+        PS C:\> Invoke-ELExchangeLogConvert -Path "\\SRV01\Logs\Exchange\Staging" -Destination "\\SRV01\Logs\Exchange\Reporting" -Archive "\\SRV01\Logs\Exchange\Archive"
 
+        Same behavior as in the first example, but the output path and the archival path is specified explicitly.
+        Alias "Path" is used on the parameter "Source".
+
+    .EXAMPLE
+        PS C:\> Invoke-ELExchangeLogConvert -Source "\\$($env:USERDNSDOMAIN)\System\Logs\Exchange\Staging" -Destination "\\$($env:USERDNSDOMAIN)\System\Logs\Exchange\Reporting" -Archive "\\$($env:USERDNSDOMAIN)\system\Logs\Exchange\Archive" -MaxFileCount 1000 -LogFile "C:\Administration\Logs\Exchange\ExchangeLogConvert.log"
+
+        In this case, the function will process a maxium of 1000 files (default is 200) and actions will be logged in logfile "C:\Administration\Logs\Exchange\ExchangeLogConvert.log"
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
+        [Parameter(Mandatory = $true)]
+        [Alias("Path")]
         [String]
         $Source,
 

--- a/ExchangeLogs/functions/Invoke-ELExchangeLogConvert.ps1
+++ b/ExchangeLogs/functions/Invoke-ELExchangeLogConvert.ps1
@@ -1,0 +1,308 @@
+﻿function Invoke-ELExchangeLogConvert {
+    <#
+    .SYNOPSIS
+        Convert frunction to recursively process a folder structure and convert exchange logs to CSV files
+
+    .DESCRIPTION
+        This one is a utility function inside the ExchangeLogs module.
+        It's intendet to parse through a folder structure (staging directory, filled by Invoke-ELCentralizeLogging), find all exchange logfiles (supported by the module) and convert the files into flatten and better read-/processable CSV files.
+
+        The intented workflow provided by this function:
+          - Parse through "Source" folder structure and find logfiles
+          - convert logfiles to csv files and put them in the "Destination" folder. The folder structrue from source directory will be preserved and rebuild in destination folder
+          - Processed files will be move to "Archive" folder. The folder structrue from source directory will be preserved and rebuild in archive folder.
+
+        Requirements:
+          - The users needs read/write permission on the central network share
+
+        The workflow will be:
+        - First, find all logs and centralize them into a staging-folder with 'Invoke-ELCentralizeLogging'
+        - Second, process staging-folder with 'Invoke-ELExchangeLogConvert' and build read- and processable CSV files in a reporting-folder
+        - Use other BI-/Analytical tools to process the CSV Files in the reporting folder
+
+    .PARAMETER Source
+        Path to folder where logfiles are stored for processing
+        This one can also called 'staging directory'
+
+    .PARAMETER Destination
+        Path to store converted CSV files from exchange service logs
+        This one can also called 'reporting directory'
+
+        Default value: A folder "Reporting" next to the folder specified in source parameter
+
+    .PARAMETER Archive
+        Path fo archiving the processed exchange service log files out of the source directory
+        This is only for archival reason.
+        If no folder is specified, the logs in the source folder will be deleted!
+
+        Default value: A folder "Archive" next to the folder specified in source parameter
+
+    .PARAMETER Filter
+        Name filter for files to be processed in the source directory
+
+        Default value: *.log
+
+    .PARAMETER MaxFileCount
+        Amount of files processed in a processing cycle per directory.
+        The higher the number, the more memory and time is consumed for processing.
+        Assume usally at least 24 files per service (SMTP, IMAP, POP, ...) per exchange server
+
+        Default value: 200
+
+    .PARAMETER LogFile
+        The logfile to archive processing information.
+
+        Default value: -not specified-
+        Recommended:   C:\Administration\Logs\Exchange\ExchangeLogConvert.log
+
+    .PARAMETER WhatIf
+        If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+
+    .PARAMETER Confirm
+        If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
+    .EXAMPLE
+        PS C:\> Invoke-ELExchangeLogConvert -Source "\\SRV01\Logs\Exchange\Staging" -Destination "\\SRV01\Logs\Exchange\Reporting" -Archive "\\SRV01\Logs\Exchange\Archive"
+
+
+    .EXAMPLE
+        PS C:\> Invoke-ELExchangeLogConvert -Source "\\$($env:USERDNSDOMAIN)\System\Logs\Exchange\Staging" -Destination "\\$($env:USERDNSDOMAIN)\System\Logs\Exchange\Reporting" -Archive "\\$($env:USERDNSDOMAIN)\system\Logs\Exchange\Archive" -MaxFileCount 1000 -Log "C:\Administration\Logs\Exchange\ExchangeLogConvert.log"
+
+#>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        [String]
+        $Source,
+
+        [String]
+        $Destination = "$(Split-Path -Path $Source)\Reporting",
+
+        [String]
+        $Archive = "$(Split-Path -Path $Source)\Archive",
+
+        [String]
+        $Filter = "*.log",
+
+        [int]
+        $MaxFileCount = 200,
+
+        [String]
+        $LogFile = "C:\Administration\Logs\Exchange\ExchangeLogConvert.log"
+    )
+
+    begin {}
+
+    process {}
+
+    end {
+        #region Init and prerequisites
+        if ($LogFile) { Initialize-LogFile -LogFile $LogFile -AlternateLogName $MyInvocation.MyCommand -LogInstanceName "ExchangeLogs" }
+        Write-PSFMessage -Level Host -Message "----- Start script -----" -Tag "ExchangeLogs"
+
+
+        # variables
+        Write-PSFMessage -Level System -Message "Initialize variables" -Tag "ExchangeLogs"
+        if ($Source.EndsWith("\")) { $Source = $Source.TrimEnd('\') }
+        if ($Destination.EndsWith("\")) { $Destination = $Destination.TrimEnd('\') }
+        if ($Archive.EndsWith("\")) { $Archive = $Archive.TrimEnd('\') }
+
+        $dateStamp = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
+
+
+        # check paths
+        Write-PSFMessage -Level System -Message "Checking source-, destination- and archival-directory" -Tag "ExchangeLogs"
+        # source
+        try {
+            $sourceDir = $Source | Get-Item -ErrorAction Stop
+        } catch {
+            Stop-PSFFunction -Message "Source directory not found! (Message: $($_.exception.message))" -ErrorRecord $_ -Exception $_.exception -ErrorAction Stop -Tag "ExchangeLogs"
+            throw
+        }
+        # destination
+        try {
+            $destinationDir = $Destination | Get-Item -ErrorAction Stop
+        } catch {
+            Stop-PSFFunction -Message "Destination directory not found! (Message: $($_.exception.message))" -ErrorRecord $_ -Exception $_.exception -ErrorAction Stop -Tag "ExchangeLogs"
+            throw
+        }
+        # archive
+        try {
+            $archiveDir = $Archive | Get-Item -ErrorAction Stop
+        } catch {
+            Stop-PSFFunction -Message "Archive directory not found! (Message: $($_.exception.message))" -ErrorRecord $_ -Exception $_.exception -ErrorAction Stop -Tag "ExchangeLogs"
+            throw
+        }
+
+
+        #endregion Init and prerequisites
+
+
+
+        #region recursing function
+        function Invoke-SubDirectoryProcessing {
+            [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+            param (
+                $SourceDir,
+
+                $DestinationDir,
+
+                $ArchiveDir,
+
+                $Filter,
+
+                $LogFile,
+
+                [string]
+                $DateStamp,
+
+                [int]
+                $MaxFileCount,
+
+                [String]
+                $NamePart
+            )
+
+            $subDirectory = $SourceDir | Get-ChildItem -Directory
+            foreach ($directory in $subDirectory) {
+                Write-PSFMessage -Level Verbose -Message "Working on directory '$($directory.fullname)'" -Tag "ExchangeLogs"
+                # variables
+                $destPath = "$($DestinationDir)\$($directory.Name)"
+                $archivePath = "$($ArchiveDir)\$($directory.Name)"
+                if ($NamePart) { $NamePart = "$($NamePart)-$($directory.Name)" } else { $NamePart = $directory.Name }
+                $tempFile = "$($env:TEMP)\ELExchangeLogConvert_$([guid]::NewGuid().tostring()).csv"
+
+
+                # folder tests
+                Write-PSFMessage -Level System -Message "Checking directory '$($destPath)' exists" -Tag "ExchangeLogs"
+                if (-not (Test-Path -Path $destPath)) {
+                    try {
+                        $null = New-Item -Path $destPath -ItemType Directory -Force -ErrorAction Stop
+                    } catch {
+                        Stop-PSFFunction -Message "Error creating '$($destPath)' (Message: $($_.exception.message))" -ErrorRecord $_ -Exception $_.exception -ErrorAction Stop -Tag "ExchangeLogs"
+                        throw
+                    }
+                }
+
+                Write-PSFMessage -Level System -Message "Checking directory '$($archivePath)' exists" -Tag "ExchangeLogs"
+                if (-not (Test-Path -Path $archivePath)) {
+                    try {
+                        $null = New-Item -Path $archivePath -ItemType Directory -Force -ErrorAction Stop
+                    } catch {
+                        Stop-PSFFunction -Message "Error creating '$($archivePath)' (Message: $($_.exception.message))" -ErrorRecord $_ -Exception $_.exception -ErrorAction Stop -Tag "ExchangeLogs"
+                        throw
+                    }
+                }
+
+
+                # file processing
+                $filesToProcess = $directory | Get-ChildItem -Filter $Filter -File -Force | Select-Object -First $MaxFileCount
+                if ($filesToProcess) {
+                    Write-PSFMessage -Level Verbose -Message "$($filesToProcess.count) files to process in directory '$($directory.name)'" -Tag "ExchangeLogs"
+
+
+                    # import and convert data from logfiles
+                    Write-PSFMessage -Level System -Message "Start ExchangeLog conversion in temp file '$($tempFile)'" -Tag "ExchangeLogs"
+                    try {
+                        if ($pscmdlet.ShouldProcess("$($filesToProcess.count) files in $($directory) and save results to $($tempFile)", "Convert")) {
+                            $filesToProcess | Get-ELExchangeLog -ErrorAction Stop | Export-Csv -Path $tempFile -Delimiter ";" -Encoding UTF8 -NoTypeInformation -Force -Append -ErrorAction Stop
+                        }
+                    } catch {
+                        Stop-PSFFunction -Message "Error importing and converting data from folder '$($directory.fullname)' (Message: $($_.exception.message))" -ErrorRecord $_ -Exception $_.exception -ErrorAction Stop -Tag "ExchangeLogs"
+                        throw
+                    }
+                    Write-PSFMessage -Level System -Message "Finsh conversion into temp file '$($tempFile)'" -Tag "ExchangeLogs"
+
+
+                    # explort data to csv file
+                    $exportFilePath = "$($destPath)\$($NamePart)_$($DateStamp).csv"
+                    Write-PSFMessage -Level System -Message "Copy temp file to destination '$($exportFilePath)'" -Tag "ExchangeLogs"
+                    try {
+                        if (Test-Path -Path $exportFilePath) {
+                            # unlikely, but possible
+                            if ($pscmdlet.ShouldProcess("Content from '$($tempFile)' into existing file $($exportFilePath)", "Add")) {
+                                Get-Content -Path $tempFile -ErrorAction Stop | Out-File -FilePath $exportFilePath -Encoding UTF8 -Append -ErrorAction Stop
+                                $exportFile = Get-Item -Path $exportFilePath -ErrorAction Stop
+                            }
+                        } else {
+                            # hopefully, the usual case
+                            if ($pscmdlet.ShouldProcess("'$($tempFile)' to '$($exportFilePath)'", "Copy")) {
+                                $exportFile = Copy-Item -Path $tempFile -Destination $exportFilePath -PassThru -ErrorAction Stop
+                            }
+                        }
+                    } catch {
+                        Stop-PSFFunction -Message "Error exporting data to csv file '$($exportFilePath)' (Message: $($_.exception.message))" -ErrorRecord $_ -Exception $_.exception -ErrorAction Stop -Tag "ExchangeLogs"
+                        throw
+                    }
+                    Write-PSFMessage -Level Verbose -Message "Done with data export. Filesize: $($exportFile.Length / 1KB) KB, File: $($exportFile.FullName)" -Tag "ExchangeLogs"
+
+
+                    # temp file cleanup
+                    Write-PSFMessage -Level System -Message "Going to clean up '$($tempFile)'" -Tag "ExchangeLogs"
+                    if ($pscmdlet.ShouldProcess("$($tempFile)", "Remove")) {
+                        Remove-Item -Path $tempFile -Force -Confirm:$false -WhatIf:$false
+                    }
+
+
+                    # move processed data to archive
+                    Write-PSFMessage -Level Verbose -Message "Moving processed files to '$($archivePath)'" -Tag "ExchangeLogs"
+                    try {
+                        if ($pscmdlet.ShouldProcess("$($filesToProcess.count) files from '$($destPath)' to '$($archivePath)'", "Move")) {
+                            $filesToProcess | Move-Item -Destination $archivePath -Force -ErrorAction Stop
+                        }
+                    } catch {
+                        Stop-PSFFunction -Message "Error moving files to archive directory '$($archivePath)'  (Message: $($_.exception.message))" -ErrorRecord $_ -Exception $_.exception -ErrorAction Stop -Tag "ExchangeLogs"
+                        throw
+                    }
+                } else {
+                    Write-PSFMessage -Level System -Message "No files to process in directory '$($directory.name)'" -Tag "ExchangeLogs"
+                }
+
+
+                # invoke recursion down the subdirectories
+                Write-PSFMessage -Level System -Message "Calling recursive function for next directory" -Tag "ExchangeLogs"
+                $paramsSubDirectoryProcessing = @{
+                    "SourceDir"      = $directory
+                    "DestinationDir" = $destPath
+                    "ArchiveDir"     = $archivePath
+                    "Filter"         = $Filter
+                    "MaxFileCount"   = $MaxFileCount
+                    "Log"            = $LogFile
+                    "DateStamp"      = $DateStamp
+                    "NamePart"       = $NamePart
+                }
+                if (Test-PSFParameterBinding -ParameterName "Whatif") { $paramsSubDirectoryProcessing.Add("Whatif", $true) }
+                if (Test-PSFParameterBinding -ParameterName "Confirm") { $paramsSubDirectoryProcessing.Add("Confirm", $true) }
+                Invoke-SubDirectoryProcessing @paramsSubDirectoryProcessing
+
+
+                # trim name part
+                if ($NamePart) { $NamePart = $NamePart.TrimEnd("-$($directory.Name)") }
+            }
+        }
+
+
+        #endregion recursing function
+
+
+
+        #region main script
+        Write-PSFMessage -Level Host -Message "Start parsing '$($Source)' for log files to process." -Tag "ExchangeLogs"
+
+        $paramsSubDirectoryProcessing = @{
+            "SourceDir"      = $Source
+            "DestinationDir" = $Destination
+            "ArchiveDir"     = $Archive
+            "Filter"         = $Filter
+            "MaxFileCount"   = $MaxFileCount
+            "Log"            = $LogFile
+            "DateStamp"      = $DateStamp
+            "NamePart"       = $NamePart
+        }
+        if (Test-PSFParameterBinding -ParameterName "Whatif") { $paramsSubDirectoryProcessing.Add("Whatif", $true) }
+        if (Test-PSFParameterBinding -ParameterName "Confirm") { $paramsSubDirectoryProcessing.Add("Confirm", $true) }
+        Invoke-SubDirectoryProcessing @paramsSubDirectoryProcessing
+
+        Write-PSFMessage -Level Host -Message "*** Finishing script ***" -Tag "ExchangeLogs"
+        #endregion main script
+    }
+}

--- a/ExchangeLogs/internal/functions/Import-LogData.ps1
+++ b/ExchangeLogs/internal/functions/Import-LogData.ps1
@@ -26,9 +26,9 @@
     $content = $File | Get-Content
 
     # split metadata and logcontent (first lines fo logfile)
-    $metadata = $content -match '^#.*'
+    $metadata = $content -match '^#.*' | Select-Object -First 7 -Unique
     $header = $metadata[-1].split(": ")[-1]
-    $logcontent = $content -notmatch $header
+    $logcontent = $content -match '^\d.*'
 
     # query meta data informations into hashtable
     $metadataHash = [ordered]@{}

--- a/ExchangeLogs/internal/functions/Initialize-LogFile.ps1
+++ b/ExchangeLogs/internal/functions/Initialize-LogFile.ps1
@@ -31,7 +31,7 @@
 
     if (Test-Path -Path $LogFile -IsValid) {
         if (Test-Path -Path $LogFile -PathType Container) {
-            $LogFile = Join-Path -Path $LogFile AlternateLogName
+            $LogFile = Join-Path -Path $LogFile -ChildPath $AlternateLogName
         }
 
         $logFilePath = Split-Path -Path $LogFile

--- a/ExchangeLogs/internal/functions/Initialize-LogFile.ps1
+++ b/ExchangeLogs/internal/functions/Initialize-LogFile.ps1
@@ -1,0 +1,54 @@
+﻿function Initialize-LogFile {
+<#
+    .SYNOPSIS
+        Test for valid file and set PSF Logging provider
+
+    .DESCRIPTION
+        Test for valid file and create logfil directory if needed
+
+    .PARAMETER LogFile
+        Name of the LogType from the meta data line in a logfile
+
+    .PARAMETER AlternateLogName
+        An alternative name, if the provided logfile is only a directory, without filename
+
+    .PARAMETER LogInstanceName
+        The name of the Instance for the PSFramework logfile logging provider
+
+    .EXAMPLE
+        PS C:\> Initialize-LogFile -LogFile $LogFile -AlternateLogName $MyInvocation.MyCommand
+
+        Test for valid file and create logfil directory if needed
+#>
+    [CmdletBinding()]
+    param (
+        $LogFile,
+
+        $AlternateLogName,
+
+        $LogInstanceName
+    )
+
+    if (Test-Path -Path $LogFile -IsValid) {
+        if (Test-Path -Path $LogFile -PathType Container) {
+            $LogFile = Join-Path -Path $LogFile AlternateLogName
+        }
+
+        $logFilePath = Split-Path -Path $LogFile
+        if (-not (Test-Path -Path $logFilePath -PathType Container)) {
+            try {
+                $null = New-Item -Path $logFilePath -ItemType Directory -Force -ErrorAction Stop
+            } catch {
+                Stop-PSFFunction -Message "Unable to create logfile folder '$($logFilePath)'" -ErrorAction Stop -Tag "ExchangeLogs"
+                throw
+            }
+        }
+
+        # enable logging provider to write logging information (only events with Warning, Critical, Output, Significant, VeryVerbose, Verbose, SomewhatVerbose, System)
+        Set-PSFLoggingProvider -Name logfile -InstanceName $LogInstanceName -Enabled $true -FilePath $LogFile -IncludeTags "ExchangeLogs" -MinLevel 1 -MaxLevel 6
+
+    } else {
+        Stop-PSFFunction -Message "Invalid Logfile '$($LogFile)' specified." -ErrorAction Stop -Tag "ExchangeLogs"
+        throw
+    }
+}


### PR DESCRIPTION
## 1.3.0 (2020-09-02)
- New: Invoke-ELCentralizeLogging
    - Workflow function intendet to create a centralized logging directory to gather logfiles (supported by the module) from all exchange servers into a single directory or fileshare and withing a folder structure eligible for further processing.
    - See help for more information
- New: Invoke-ELExchangeLogConvert
    - Workflow function intendet to parse through a folder structure (staging directory, filled by Invoke-ELCentralizeLogging), find all exchange logfiles (supported by the module) and convert the files into flatten and better read-/processable CSV files.
    - See help for more information
- Fix: Get-ELExchangeLog
    - Function new can handle logs with multiple metadata lines in the conent. (service restarts or config changes can bring additional header information to W3C logfiles)
